### PR TITLE
Fix tests on linux

### DIFF
--- a/pkg/sh/exec.go
+++ b/pkg/sh/exec.go
@@ -51,7 +51,7 @@ func RunOutput(ctx *task.Context, name string, args ...string) (string, error) {
 // RunCmd runs the provided command.
 func RunCmd(ctx *task.Context, cmd *exec.Cmd) error {
 	LogCmd(ctx, cmd)
-	if cmd.Stdout == nil {
+	if ctx.Verbose && cmd.Stdout == nil {
 		cmd.Stdout = ctx
 	}
 	if cmd.Stderr == nil {

--- a/pkg/sh/exec.go
+++ b/pkg/sh/exec.go
@@ -51,7 +51,7 @@ func RunOutput(ctx *task.Context, name string, args ...string) (string, error) {
 // RunCmd runs the provided command.
 func RunCmd(ctx *task.Context, cmd *exec.Cmd) error {
 	LogCmd(ctx, cmd)
-	if ctx.Verbose && cmd.Stdout == nil {
+	if cmd.Stdout == nil {
 		cmd.Stdout = ctx
 	}
 	if cmd.Stderr == nil {

--- a/pkg/sh/io.go
+++ b/pkg/sh/io.go
@@ -138,6 +138,10 @@ func DirectoryExists(path string) (bool, error) {
 			return false, nil
 		}
 
+		if exists, err := DirectoryExists(filepath.Dir(path)); !exists || err != nil {
+			return false, err
+		}
+
 		return false, fmt.Errorf("failed statting path %s: %v", path, err)
 	}
 
@@ -150,6 +154,10 @@ func FileExists(path string) (bool, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
+		}
+
+		if exists, err := DirectoryExists(filepath.Dir(path)); !exists || err != nil {
+			return false, err
 		}
 
 		return false, fmt.Errorf("failed statting path %s: %v", path, err)

--- a/pkg/sh/io_test.go
+++ b/pkg/sh/io_test.go
@@ -151,7 +151,7 @@ func TestDirectoryExists(t *testing.T) {
 
 	exists, err := sh.DirectoryExists(tempDir)
 	if err != nil {
-		t.Fatalf("failed testing for directory existance: %v", err)
+		t.Fatalf("failed testing for directory existence: %v", err)
 	}
 
 	if !exists {
@@ -160,7 +160,7 @@ func TestDirectoryExists(t *testing.T) {
 
 	exists, err = sh.DirectoryExists(filepath.Join(tempDir, "noexisty"))
 	if err != nil {
-		t.Fatalf("failed testing for directory existance: %v", err)
+		t.Fatalf("failed testing for directory existence: %v", err)
 	}
 
 	if exists {
@@ -177,7 +177,7 @@ func TestFileExists(t *testing.T) {
 
 	exists, err := sh.FileExists(tempFile.Name())
 	if err != nil {
-		t.Fatalf("failed testing for directory existance: %v", err)
+		t.Fatalf("failed testing for directory existence: %v", err)
 	}
 
 	if !exists {
@@ -186,7 +186,7 @@ func TestFileExists(t *testing.T) {
 
 	exists, err = sh.FileExists(filepath.Join(tempFile.Name(), "noexisty"))
 	if err != nil {
-		t.Fatalf("failed testing for directory existance: %v", err)
+		t.Fatalf("failed testing for directory existence: %v", err)
 	}
 
 	if exists {

--- a/task/internal/prefix_writer.go
+++ b/task/internal/prefix_writer.go
@@ -1,6 +1,8 @@
 package internal
 
-import "io"
+import (
+	"io"
+)
 
 // NewPrefixWriter creates a PrefixWriter.
 func NewPrefixWriter(w io.Writer) *PrefixWriter {


### PR DESCRIPTION
So this should fix the problem on Linux. On Windows and nicer OSes, we fail early anyways and don't pay the cost of extra recursive calls to the `stat` syscall. On Linux, we make such recursive calls only as much as we need until we get a `true` _OR_ a non-`nil` error.