### PR TITLE
MHOUSE-857: Skip archiving empty paths

### DIFF
--- a/pkg/sh/archive.go
+++ b/pkg/sh/archive.go
@@ -66,7 +66,8 @@ func ArchiveTGZ(ctx *task.Context, src, dest string) error {
 			return err
 		}
 
-		if baseDir == path {
+		// If this 'file' is the same as the base directory we're traversing, ignore it.
+		if baseDir == path || fi.Name() == baseDir {
 			return nil
 		}
 
@@ -77,10 +78,6 @@ func ArchiveTGZ(ctx *task.Context, src, dest string) error {
 
 		if baseDir != "" {
 			header.Name, _ = filepath.Rel("/", strings.TrimPrefix(path, src))
-		}
-
-		if header.Name == "" {
-			return nil
 		}
 
 		if err = tw.WriteHeader(header); err != nil {

--- a/pkg/sh/archive.go
+++ b/pkg/sh/archive.go
@@ -79,6 +79,10 @@ func ArchiveTGZ(ctx *task.Context, src, dest string) error {
 			header.Name, _ = filepath.Rel("/", strings.TrimPrefix(path, src))
 		}
 
+		if header.Name == "" {
+			return nil
+		}
+
 		if err = tw.WriteHeader(header); err != nil {
 			return err
 		}

--- a/pkg/sh/archive.go
+++ b/pkg/sh/archive.go
@@ -66,8 +66,7 @@ func ArchiveTGZ(ctx *task.Context, src, dest string) error {
 			return err
 		}
 
-		// If this 'file' is the same as the base directory we're traversing, ignore it.
-		if baseDir == path || fi.Name() == baseDir {
+		if baseDir == path {
 			return nil
 		}
 
@@ -78,6 +77,11 @@ func ArchiveTGZ(ctx *task.Context, src, dest string) error {
 
 		if baseDir != "" {
 			header.Name, _ = filepath.Rel("/", strings.TrimPrefix(path, src))
+		}
+
+		// If this 'file' is the same as the base directory we're traversing, ignore it.
+		if header.Name == "" {
+			return nil
 		}
 
 		if err = tw.WriteHeader(header); err != nil {


### PR DESCRIPTION
When a directory is passed as the input argument to the archive function, we should skip archiving the directory name itself (which is empty, relative to itself).