### PR TITLE
Added RunBuffered for preservation of command output in mutlithreaded…

### DIFF
--- a/pkg/sh/exec.go
+++ b/pkg/sh/exec.go
@@ -48,6 +48,15 @@ func RunOutput(ctx *task.Context, name string, args ...string) (string, error) {
 	return strings.TrimRight(output.String(), "\r\n"), err
 }
 
+// RunBuffered runs the specified command and returns the actual command exectued, stdout, and stderr.
+func RunBuffered(ctx *task.Context, name string, args ...string) (string, string, string, error) {
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	err := cmd.Run()
+	return cmd.String(), stdout.String(), stderr.String(), err
+}
+
 // RunCmd runs the provided command.
 func RunCmd(ctx *task.Context, cmd *exec.Cmd) error {
 	LogCmd(ctx, cmd)


### PR DESCRIPTION
Adds a ```RunBuffered``` function: 

1) ```RunBuffered``` returns the actual command executed instead of logging it immediately as in other functions in ```exec.go```. In multithreaded environments this lets us control when we print the command to the console instead of race winners being printed first.
 
2) ```RunBuffered``` buffers and returns stdout and stderr. Again, this lets us control when we print program output to the console.

This function was implemented to hide buffer handling logic that had been written as part of parallel linting changes.