### PR TITLE
Add function to upload io.Reader to S3

### DIFF
--- a/pkg/sh/net.go
+++ b/pkg/sh/net.go
@@ -69,8 +69,8 @@ func DownloadS3(ctx *task.Context, from S3Object, toPath string, profile string)
 	return err
 }
 
-// UploadFileToS3 reads the file at the provided path and uploads the contents to S3.
-func UploadFileToS3(ctx *task.Context, fromPath string, to S3Object, profile string) error {
+// UploadS3 reads the file at the provided path and uploads the contents to S3.
+func UploadS3(ctx *task.Context, fromPath string, to S3Object, profile string) error {
 	ctx.Logf("s3 upload: %s -> %s/%s\n", fromPath, to.Bucket, to.Key)
 
 	var f *os.File


### PR DESCRIPTION
This PR adds a new function to upload the contents of an `io.Reader` to S3. This is helpful in cases where we want to dynamically generate file contents in memory and upload them to S3 without writing the file to disk.