### PR TITLE
Add support for unused argument detection

### DIFF
--- a/task/registry.go
+++ b/task/registry.go
@@ -24,6 +24,13 @@ func WithNamespaceSeparator(s string) RegistryOption {
 	}
 }
 
+// WithShouldErrorOnUnusedArgs sets whether we should return an error when unused args are detected.
+func WithShouldErrorOnUnusedArgs(v bool) RegistryOption {
+	return func(r *Registry) {
+		r.shouldErrorOnUnusedArgs = v
+	}
+}
+
 // NewRegistry creates a new registry.
 func NewRegistry(opts ...RegistryOption) *Registry {
 	r := &Registry{
@@ -39,9 +46,10 @@ func NewRegistry(opts ...RegistryOption) *Registry {
 
 // Registry holds all the tasks able to be run.
 type Registry struct {
-	tree        taskTree
-	nsSeparator string
-	autoNS      bool
+	tree                    taskTree
+	nsSeparator             string
+	autoNS                  bool
+	shouldErrorOnUnusedArgs bool
 }
 
 // Tasks returns all the tasks and pseudo-tasks.

--- a/task/registry_test.go
+++ b/task/registry_test.go
@@ -1,0 +1,93 @@
+package task
+
+import (
+	"testing"
+)
+
+func TestUnusedArgs(t *testing.T) {
+	registry := NewRegistry()
+
+	fooArgs := []string{"bar", "baz"}
+	registry.Declare("foo").Description("the foo command will do nothing").OptionalArgs(fooArgs...).Do(func(ctx *Context) error {
+		return nil
+	})
+
+	quuxArgs := []string{"quuz", "corge"}
+	registry.Declare("quux").Description("the quux command will do nothing").OptionalArgs(quuxArgs...).Do(func(ctx *Context) error {
+		return nil
+	})
+
+	unusedArgs := getUnusedArgs(registry.Tasks(), globalArgs{
+		"": {
+			"bar":    "bar",
+			"baz":    "baz",
+			"quuz":   "quuz",
+			"unused": "unused",
+		},
+		"quux": {
+			"corge": "corge",
+			"fake":  "fake",
+		},
+		"invalidTest": {
+			"bar": "bar",
+		},
+	})
+
+	// Using a map because there is no inherent order that unusedArgs should be.
+	expectedUnusedArgs := map[string]bool{"unused": true, "quux:fake": true, "invalidTest:bar": true}
+
+	if len(unusedArgs) != len(expectedUnusedArgs) {
+		t.Fatalf("expected args length of %d, instead got %d", len(expectedUnusedArgs), len(unusedArgs))
+	} else {
+		for _, arg := range unusedArgs {
+			if _, ok := expectedUnusedArgs[arg]; !ok {
+				t.Fatalf("got unexpected arg %s", arg)
+			}
+		}
+	}
+}
+
+func TestShouldExitOnUnusedArgs(t *testing.T) {
+	registryErrorOnUnused := NewRegistry(WithShouldErrorOnUnusedArgs(true))
+	registryNoErrorOnUnused := NewRegistry(WithShouldErrorOnUnusedArgs(false))
+
+	fooArgs := []string{"bar", "baz"}
+	registryErrorOnUnused.Declare("foo").Description("the foo command will do nothing").OptionalArgs(fooArgs...).Do(func(ctx *Context) error {
+		return nil
+	})
+	registryNoErrorOnUnused.Declare("foo").Description("the foo command will do nothing").OptionalArgs(fooArgs...).Do(func(ctx *Context) error {
+		return nil
+	})
+
+	quuxArgs := []string{"quuz", "corge"}
+	registryErrorOnUnused.Declare("quux").Description("the quux command will do nothing").OptionalArgs(quuxArgs...).Do(func(ctx *Context) error {
+		return nil
+	})
+	registryNoErrorOnUnused.Declare("quux").Description("the quux command will do nothing").OptionalArgs(quuxArgs...).Do(func(ctx *Context) error {
+		return nil
+	})
+
+	testCases := []struct {
+		args        []string
+		shouldError bool
+	}{
+		{[]string{"foo", "--bar", "--baz", "quux"}, false},
+		{[]string{"foo", "--bar", "--baz", "quux", "--fake"}, true},
+		{[]string{"foo", "--bar", "--baz", "quux", "--quux:corge"}, false},
+		{[]string{"foo", "--bar", "--baz", "quux", "--quux:fake"}, true},
+	}
+
+	for _, tc := range testCases {
+		err := Run(registryErrorOnUnused, tc.args)
+		if tc.shouldError && err == nil {
+			t.Errorf("expecting an error")
+		} else if !tc.shouldError && err != nil {
+			t.Errorf("not expecting an error")
+		}
+
+		err = Run(registryNoErrorOnUnused, tc.args)
+		if err != nil {
+			t.Errorf("not expecting an error")
+		}
+	}
+}


### PR DESCRIPTION
This commit adds functionality for warning the user when unused arguments have been provided. In addition, it provides the option to exit early and run no tasks in the case that unused arguments were detected.

![image](https://user-images.githubusercontent.com/25668856/228619941-066c7bb7-e3d5-4e1b-8741-d2161478ff07.png)