### PR TITLE
MHOUSE-4709: Add method to copy context args

### DIFF
--- a/task/context.go
+++ b/task/context.go
@@ -60,3 +60,12 @@ func (ctx *Context) Logf(format string, v ...interface{}) {
 func (ctx *Context) Write(p []byte) (n int, err error) {
 	return ctx.w.Write(p)
 }
+
+// CopyArgs returns a copy of the current context's task arguments.
+func (ctx *Context) CopyArgs() map[string]string {
+	cpy := make(map[string]string, len(ctx.taskArgs))
+	for k, v := range ctx.taskArgs {
+		cpy[k] = v
+	}
+	return cpy
+}


### PR DESCRIPTION
This PR adds a method to copy context task arguments. This can be useful for creating a `task.NewContext(context.Background(), differentWriter, sameArgs)` for used in sub-tasks or parallel tasks of a main context.