### PR TITLE
MHOUSE-6810: Add support for declaring post-task actions

### DIFF
--- a/task/builder.go
+++ b/task/builder.go
@@ -3,7 +3,8 @@ package task
 // build begins building a task.
 func build(name string) *Builder {
 	task := &declaredTask{
-		name: name,
+		name:            name,
+		finalizeOnError: true,
 	}
 	return &Builder{task: task}
 }
@@ -87,6 +88,18 @@ func (b *Builder) Hide() *Builder {
 	return b
 }
 
+// SkipFinallyOnError declares that finalizers should not run if there were errors.
+func (b *Builder) SkipFinallyOnError() *Builder {
+	b.task.finalizeOnError = false
+	return b
+}
+
+// Finally declares executors to be run after the main task executor is finished.
+func (b *Builder) Finally(executors ...Executor) *Builder {
+	b.task.finalizers = executors
+	return b
+}
+
 type declaredTask struct {
 	declaredArgs    []DeclaredTaskArg
 	dependencies    []string
@@ -95,6 +108,8 @@ type declaredTask struct {
 	executor        Executor
 	continueOnError bool
 	hidden          bool
+	finalizeOnError bool
+	finalizers      []Executor
 }
 
 func (t *declaredTask) ContinueOnError() bool {
@@ -117,4 +132,10 @@ func (t *declaredTask) Executor() Executor {
 }
 func (t *declaredTask) Name() string {
 	return t.name
+}
+func (t *declaredTask) FinalizeOnError() bool {
+	return t.finalizeOnError
+}
+func (t *declaredTask) Finalizers() []Executor {
+	return t.finalizers
 }

--- a/task/run.go
+++ b/task/run.go
@@ -76,6 +76,11 @@ func Run(registry *Registry, arguments []string) error {
 
 		startTime := time.Now()
 		err = executor(ctx)
+		if err == nil || t.FinalizeOnError() {
+			for _, finalizer := range t.Finalizers() {
+				finalizer(ctx)
+			}
+		}
 		finishedTime := time.Now()
 
 		writer.SetPrefix(nil)

--- a/task/run.go
+++ b/task/run.go
@@ -78,8 +78,7 @@ func Run(registry *Registry, arguments []string) error {
 		err = executor(ctx)
 		if err == nil || t.FinalizeOnError() {
 			for _, finalizer := range t.Finalizers() {
-				err := finalizer(ctx)
-				if err != nil {
+				if err := finalizer(ctx); err != nil {
 					writer.SetPrefix(nil)
 					ctx.Logln(ui.Warning("WARNING"), "|", "Error during finalization:", err.Error())
 					writer.SetPrefix(prefix)

--- a/task/run_test.go
+++ b/task/run_test.go
@@ -1,0 +1,53 @@
+package task
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTaskWithFinalizer(t *testing.T) {
+	finalizedCount := 0
+
+	finalizer := func(ctx *Context) error {
+		finalizedCount++
+		return nil
+	}
+
+	testCases := []struct {
+		finalizers             []Executor
+		taskError              bool
+		finalizeOnError        bool
+		expectedFinalizedCount int
+	}{
+		// No finalizeer
+		{[]Executor{}, false, true, 0},
+		// Single finalizer
+		{[]Executor{finalizer}, false, true, 1},
+		// Multiple finalizers
+		{[]Executor{finalizer, finalizer, finalizer}, false, true, 3},
+		// Should finalize by default if task had error
+		{[]Executor{finalizer}, true, true, 1},
+		// SkipFinallyOnError should prevent finalizer execution if task had error
+		{[]Executor{finalizer}, true, false, 0},
+	}
+
+	for _, tc := range testCases {
+		finalizedCount = 0
+		registry := NewRegistry()
+		b := registry.Declare("foo").Finally(tc.finalizers...)
+		if !tc.finalizeOnError {
+			b.SkipFinallyOnError()
+		}
+		b.Do(func(ctx *Context) error {
+			if tc.taskError {
+				return errors.New("task failed")
+			}
+			return nil
+		})
+
+		Run(registry, []string{"foo"})
+		if finalizedCount != tc.expectedFinalizedCount {
+			t.Errorf("Expected %d finalizer(s) to run but got %d", tc.expectedFinalizedCount, finalizedCount)
+		}
+	}
+}

--- a/task/sort.go
+++ b/task/sort.go
@@ -23,6 +23,7 @@ func buildGraph(allTasks []Task, requiredTaskNames []string) ([]*graphNode, erro
 	allTasksMap := make(map[string]Task)
 	for _, t := range allTasks {
 		allTasksMap[strings.ToLower(t.Name())] = t
+		// aggregate tasks which don't perform any work themselves should not have finalizers
 		if t.Executor() == nil && len(t.Finalizers()) > 0 {
 			return nil, fmt.Errorf("finalization not allowed for aggregate task '%s'", t.Name())
 		}

--- a/task/sort.go
+++ b/task/sort.go
@@ -23,6 +23,9 @@ func buildGraph(allTasks []Task, requiredTaskNames []string) ([]*graphNode, erro
 	allTasksMap := make(map[string]Task)
 	for _, t := range allTasks {
 		allTasksMap[strings.ToLower(t.Name())] = t
+		if t.Executor() == nil && len(t.Finalizers()) > 0 {
+			return nil, fmt.Errorf("finalization not allowed for aggregate task '%s'", t.Name())
+		}
 	}
 
 	var g []*graphNode

--- a/task/sort_test.go
+++ b/task/sort_test.go
@@ -98,3 +98,9 @@ func (t dummyTask) Hidden() bool {
 func (t dummyTask) Name() string {
 	return string(t)
 }
+func (t dummyTask) FinalizeOnError() bool {
+	return true
+}
+func (t dummyTask) Finalizers() []Executor {
+	return nil
+}

--- a/task/task.go
+++ b/task/task.go
@@ -9,6 +9,8 @@ type Task interface {
 	Dependencies() []string
 	Description() string
 	Executor() Executor
+	FinalizeOnError() bool
+	Finalizers() []Executor
 	Hidden() bool
 	Name() string
 }

--- a/task/tui.go
+++ b/task/tui.go
@@ -59,3 +59,12 @@ func (ui *TUI) Success(msg string) string {
 
 	return ansi.Color(msg, "green+b")
 }
+
+// Warning colors the msg as warning.
+func (ui *TUI) Warning(msg string) string {
+	if ui == nil {
+		return msg
+	}
+
+	return ansi.Color(msg, "yellow+b")
+}


### PR DESCRIPTION
Task declarations can use `.DependsOn()` if their execution relies on artifacts or actions from other tasks, e.g. building binaries and preparing a test environment for e2e testing.

Similarly, it is often desirable to perform actions *after* task execution, e.g. cleaning up or reverting the steps taken in preparation. This can currently only be done as part of the task executor itself though, which adds complexity and requires careful handling of errors during task execution to ensure the cleanup actually happens.

This PR adds the `.Finally()` builder method to specify one or more executor functions that will be run after the task even if it failed, as well as `.SkipFinallyOnError()` to only run if the task succeeded.

---
Notes on the design:
- `Finally()` uses executor functions like `Do()` instead of task names like `DependsOn()`. It is not intended to be as powerful, and performing e.g. the same cleanup step before and after the task would result in a cycle in the build graph.