### PR TITLE
MHOUSE-6810: Support for declaring post-task actions

### DIFF
--- a/task/builder.go
+++ b/task/builder.go
@@ -3,7 +3,8 @@ package task
 // build begins building a task.
 func build(name string) *Builder {
 	task := &declaredTask{
-		name: name,
+		name:            name,
+		finalizeOnError: true,
 	}
 	return &Builder{task: task}
 }
@@ -87,6 +88,18 @@ func (b *Builder) Hide() *Builder {
 	return b
 }
 
+// SkipFinallyOnError declares that finalizers should not run if there were errors.
+func (b *Builder) SkipFinallyOnError() *Builder {
+	b.task.finalizeOnError = false
+	return b
+}
+
+// Finally declares executors to be run after the main task executor is finished.
+func (b *Builder) Finally(executors ...Executor) *Builder {
+	b.task.finalizers = executors
+	return b
+}
+
 type declaredTask struct {
 	declaredArgs    []DeclaredTaskArg
 	dependencies    []string
@@ -95,6 +108,8 @@ type declaredTask struct {
 	executor        Executor
 	continueOnError bool
 	hidden          bool
+	finalizeOnError bool
+	finalizers      []Executor
 }
 
 func (t *declaredTask) ContinueOnError() bool {
@@ -117,4 +132,10 @@ func (t *declaredTask) Executor() Executor {
 }
 func (t *declaredTask) Name() string {
 	return t.name
+}
+func (t *declaredTask) FinalizeOnError() bool {
+	return t.finalizeOnError
+}
+func (t *declaredTask) Finalizers() []Executor {
+	return t.finalizers
 }

--- a/task/run.go
+++ b/task/run.go
@@ -76,6 +76,11 @@ func Run(registry *Registry, arguments []string) error {
 
 		startTime := time.Now()
 		err = executor(ctx)
+		if err == nil || t.FinalizeOnError() {
+			for _, finalizer := range t.Finalizers() {
+				finalizer(ctx)
+			}
+		}
 		finishedTime := time.Now()
 
 		writer.SetPrefix(nil)

--- a/task/run.go
+++ b/task/run.go
@@ -78,8 +78,7 @@ func Run(registry *Registry, arguments []string) error {
 		err = executor(ctx)
 		if err == nil || t.FinalizeOnError() {
 			for _, finalizer := range t.Finalizers() {
-				err := finalizer(ctx)
-				if err != nil {
+				if err := finalizer(ctx); err != nil {
 					writer.SetPrefix(nil)
 					ctx.Logln(ui.Warning("WARNING"), "|", "Error during finalization:", err.Error())
 					writer.SetPrefix(prefix)

--- a/task/run_test.go
+++ b/task/run_test.go
@@ -1,0 +1,53 @@
+package task
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTaskWithFinalizer(t *testing.T) {
+	finalizedCount := 0
+
+	finalizer := func(ctx *Context) error {
+		finalizedCount++
+		return nil
+	}
+
+	testCases := []struct {
+		finalizers             []Executor
+		taskError              bool
+		finalizeOnError        bool
+		expectedFinalizedCount int
+	}{
+		// No finalizeer
+		{[]Executor{}, false, true, 0},
+		// Single finalizer
+		{[]Executor{finalizer}, false, true, 1},
+		// Multiple finalizers
+		{[]Executor{finalizer, finalizer, finalizer}, false, true, 3},
+		// Should finalize by default if task had error
+		{[]Executor{finalizer}, true, true, 1},
+		// SkipFinallyOnError should prevent finalizer execution if task had error
+		{[]Executor{finalizer}, true, false, 0},
+	}
+
+	for _, tc := range testCases {
+		finalizedCount = 0
+		registry := NewRegistry()
+		b := registry.Declare("foo").Finally(tc.finalizers...)
+		if !tc.finalizeOnError {
+			b.SkipFinallyOnError()
+		}
+		b.Do(func(ctx *Context) error {
+			if tc.taskError {
+				return errors.New("task failed")
+			}
+			return nil
+		})
+
+		Run(registry, []string{"foo"})
+		if finalizedCount != tc.expectedFinalizedCount {
+			t.Errorf("Expected %d finalizer(s) to run but got %d", tc.expectedFinalizedCount, finalizedCount)
+		}
+	}
+}

--- a/task/sort.go
+++ b/task/sort.go
@@ -23,6 +23,7 @@ func buildGraph(allTasks []Task, requiredTaskNames []string) ([]*graphNode, erro
 	allTasksMap := make(map[string]Task)
 	for _, t := range allTasks {
 		allTasksMap[strings.ToLower(t.Name())] = t
+		// aggregate tasks which don't perform any work themselves should not have finalizers
 		if t.Executor() == nil && len(t.Finalizers()) > 0 {
 			return nil, fmt.Errorf("finalization not allowed for aggregate task '%s'", t.Name())
 		}

--- a/task/sort.go
+++ b/task/sort.go
@@ -23,6 +23,9 @@ func buildGraph(allTasks []Task, requiredTaskNames []string) ([]*graphNode, erro
 	allTasksMap := make(map[string]Task)
 	for _, t := range allTasks {
 		allTasksMap[strings.ToLower(t.Name())] = t
+		if t.Executor() == nil && len(t.Finalizers()) > 0 {
+			return nil, fmt.Errorf("finalization not allowed for aggregate task '%s'", t.Name())
+		}
 	}
 
 	var g []*graphNode

--- a/task/sort_test.go
+++ b/task/sort_test.go
@@ -98,3 +98,9 @@ func (t dummyTask) Hidden() bool {
 func (t dummyTask) Name() string {
 	return string(t)
 }
+func (t dummyTask) FinalizeOnError() bool {
+	return true
+}
+func (t dummyTask) Finalizers() []Executor {
+	return nil
+}

--- a/task/task.go
+++ b/task/task.go
@@ -9,6 +9,8 @@ type Task interface {
 	Dependencies() []string
 	Description() string
 	Executor() Executor
+	FinalizeOnError() bool
+	Finalizers() []Executor
 	Hidden() bool
 	Name() string
 }

--- a/task/tui.go
+++ b/task/tui.go
@@ -59,3 +59,12 @@ func (ui *TUI) Success(msg string) string {
 
 	return ansi.Color(msg, "green+b")
 }
+
+// Warning colors the msg as warning.
+func (ui *TUI) Warning(msg string) string {
+	if ui == nil {
+		return msg
+	}
+
+	return ansi.Color(msg, "yellow+b")
+}


### PR DESCRIPTION
**Context:** `DependsOn()` allows tasks to build on the actions performed by other tasks. This is especially useful when multiple tasks require the same or similar setup steps, e.g. integration/e2e test tasks that need to build the same binaries, generate artifacts or prepare the filesystem before executing individual tests.

**The Problem:** Tasks may involve similarly redundant/repetitive actions after executing to e.g. revert setup steps, clean up temporary artifacts or perform other post processing actions, which can currently only be done by the task executor itself. This adds possibly redundant overhead and requires careful handling of errors to ensure post-task actions are not inadvertently skipped. Deferring the work to e.g. make generated artifacts available to other tasks via `DependsOn()` before being removed is also not possible.

**The Solution:** This PR adds the builder method `Finally(names ...string)` to optionally declare one or more tasks that should be run after the task itself has executed, regardless of its error status.

---

**Design Notes**
- `Finally()` tasks only execute if the underlying task was invoked, but regardless of whether it succeeded or failed
- If multiple tasks are run, their `Finally()` tasks will be run in reverse sort order, i.e. `A.DependsOn(B)` means `B` is executed *before* `A`, but its `Finally()` tasks are run *after* `A` and its `Finally()`
- `Finally()` can be used on any task except pure aggregate tasks which don't have an executor
- Parameters for `Finally()` can be any task(s) that **do not**
	- use `Finally()` themselves
	- have required parameters
	- depend on tasks matching either of the above
- Even if specified by multiple tasks, each `Finally()` task is only executed **once**. While generally executed in the order they were specified, a `Finally()` task use by a higher-level task may change the effective order for a lower-level one.
	- Ex: `T1.Finally("F1", "F2", "F3")`, `T2.DependsOn("T1").Finally("F2")`
	- Running `T2` executes `T1 -> T2 [finalize] F2 -> F1 -> F3`

