### PR TITLE
MHOUSE-6810: Support for declaring post-task actions

### DIFF
--- a/task/builder.go
+++ b/task/builder.go
@@ -87,6 +87,12 @@ func (b *Builder) Hide() *Builder {
 	return b
 }
 
+// Finally declares other tasks that should run after this one.
+func (b *Builder) Finally(names ...string) *Builder {
+	b.task.finally = names
+	return b
+}
+
 type declaredTask struct {
 	declaredArgs    []DeclaredTaskArg
 	dependencies    []string
@@ -95,6 +101,7 @@ type declaredTask struct {
 	executor        Executor
 	continueOnError bool
 	hidden          bool
+	finally         []string
 }
 
 func (t *declaredTask) ContinueOnError() bool {
@@ -117,4 +124,7 @@ func (t *declaredTask) Executor() Executor {
 }
 func (t *declaredTask) Name() string {
 	return t.name
+}
+func (t *declaredTask) Finally() []string {
+	return t.finally
 }

--- a/task/builder.go
+++ b/task/builder.go
@@ -87,9 +87,9 @@ func (b *Builder) Hide() *Builder {
 	return b
 }
 
-// Finally declares other tasks that should run after this one.
-func (b *Builder) Finally(names ...string) *Builder {
-	b.task.finally = names
+// Defer declares other tasks that should run after this one.
+func (b *Builder) Defer(names ...string) *Builder {
+	b.task.deferredTasks = names
 	return b
 }
 
@@ -101,7 +101,7 @@ type declaredTask struct {
 	executor        Executor
 	continueOnError bool
 	hidden          bool
-	finally         []string
+	deferredTasks   []string
 }
 
 func (t *declaredTask) ContinueOnError() bool {
@@ -125,6 +125,6 @@ func (t *declaredTask) Executor() Executor {
 func (t *declaredTask) Name() string {
 	return t.name
 }
-func (t *declaredTask) Finally() []string {
-	return t.finally
+func (t *declaredTask) DeferredTasks() []string {
+	return t.deferredTasks
 }

--- a/task/context.go
+++ b/task/context.go
@@ -8,11 +8,29 @@ import (
 )
 
 // NewContext makes a new Context.
-func NewContext(ctx context.Context, w io.Writer, taskArgs map[string]string) *Context {
-	return &Context{
+func NewContext(ctx context.Context, w io.Writer, taskArgs map[string]string, params ...ContextParam) *Context {
+	c := &Context{
 		Context:  ctx,
 		w:        w,
 		taskArgs: taskArgs,
+	}
+	for _, param := range params {
+		param(c)
+	}
+	return c
+}
+
+type ContextParam = func(ctx *Context)
+
+func WithVerbose(verbose bool) ContextParam {
+	return func(ctx *Context) {
+		ctx.Verbose = verbose
+	}
+}
+
+func WithUI(ui *TUI) ContextParam {
+	return func(ctx *Context) {
+		ctx.UI = ui
 	}
 }
 

--- a/task/run.go
+++ b/task/run.go
@@ -60,6 +60,7 @@ func Run(registry *Registry, arguments []string) error {
 		executor := t.Executor()
 		if executor == nil {
 			// this task is just an aggregate task
+			finallyTaskNames = append(t.Finally(), finallyTaskNames...)
 			continue
 		}
 
@@ -107,17 +108,17 @@ func Run(registry *Registry, arguments []string) error {
 			if task.Executor() != nil {
 				if err := task.Executor()(ctx); err != nil {
 					writer.SetPrefix(nil)
-					ctx.Logln(ui.Warning("WARN"), "  |", ui.Highlight(task.Name()), "encountered error:", err.Error())
+					ctx.Logln(ui.Warning("WARN"), "  |", ui.Highlight(task.Name()), "failed:", err.Error())
 					writer.SetPrefix(prefix)
 				} else {
-					ctx.Logln(ui.Highlight(task.Name()))
+					ctx.Logln(ui.Highlight(task.Name()), "finished")
 				}
 			}
 		}
 		writer.SetPrefix(nil)
 		ctx.Logln(ui.Success("FINISH"), "|", ui.Highlight("finalizing tasks"), "in", time.Since(startTime).String())
 	} else if err != nil {
-		// this should not happen since we verify each task
+		// should not happen since Finally() tasks are validated when building the primary task list
 		fmt.Fprintln(writer, ui.Error("WARNING"), "Building finalizing task list failed:", err.Error())
 	}
 

--- a/task/run_test.go
+++ b/task/run_test.go
@@ -1,0 +1,121 @@
+package task
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+var runOrder []string
+
+func makeExecutor(name string, shouldError bool) Executor {
+	return func(ctx *Context) error {
+		runOrder = append(runOrder, name)
+		if shouldError {
+			return fmt.Errorf("error in %s", name)
+		}
+		return nil
+	}
+}
+
+func declare(registry *Registry, name string, shouldError bool) *Builder {
+	b := registry.Declare(name)
+	b.Do(makeExecutor(name, shouldError))
+	return b
+}
+
+type testTaskCfg struct {
+	name             string
+	finally          []string
+	shouldError      bool
+	shouldFailRun    bool
+	expectedRunOrder []string
+}
+
+func runTests(t *testing.T, registry *Registry, declareTasks bool, testCases []testTaskCfg) {
+	for _, tc := range testCases {
+		runOrder = []string{}
+		if declareTasks {
+			declare(registry, tc.name, tc.shouldError).Finally(tc.finally...)
+		}
+		err := Run(registry, []string{tc.name})
+		if err == nil && tc.shouldFailRun {
+			t.Fatalf("expected error")
+		} else if err != nil && !tc.shouldFailRun {
+			t.Fatalf("expected no error")
+		}
+		if !reflect.DeepEqual(runOrder, tc.expectedRunOrder) {
+			t.Fatalf("case '%s': expected run order %v but got %v", tc.name, tc.expectedRunOrder, runOrder)
+		}
+	}
+}
+
+func TestFinally(t *testing.T) {
+	dummy := []string{}
+	reg := NewRegistry()
+
+	// Finally() allows simple tasks and aggregates thereof
+	declare(reg, "ok1", false)
+	declare(reg, "ok2", false)
+	declare(reg, "err", true)
+	declare(reg, "dep", false).DependsOn("ok1", "ok2")
+
+	// Finally() does *not* allow tasks which
+	// - have required arguments
+	declare(reg, "requiredArg", false).RequiredArg("foo")
+	// - use Finally() themselves
+	declare(reg, "hasFinally", false).Finally("ok1")
+	// - have dependencies that are not allowed
+	declare(reg, "dependsOnNotAllowed", false).DependsOn("requiredArg")
+
+	t.Run("NotAllowedInPureAggregates", func(t *testing.T) {
+		reg.Declare("t0").DependsOn("ok1", "ok2").Finally("ok1")
+		runTests(t, reg, false, []testTaskCfg{
+			{"t0", dummy, false, true, dummy},
+		})
+	})
+
+	t.Run("ShouldRunOnTaskSuccess", func(t *testing.T) {
+		runTests(t, reg, true, []testTaskCfg{
+			{"t1", []string{"ok1"}, false, false, []string{"t1", "ok1"}},
+			{"t2", []string{"ok1", "ok1", "ok2"}, false, false, []string{"t2", "ok1", "ok2"}},
+			{"t3", []string{"dep"}, false, false, []string{"t3", "ok1", "ok2", "dep"}},
+		})
+	})
+
+	t.Run("ShouldRunOnTaskFailure", func(t *testing.T) {
+		runTests(t, reg, true, []testTaskCfg{
+			{"t4", []string{"ok1"}, true, true, []string{"t4", "ok1"}},
+			{"t5", []string{"ok1", "ok2"}, true, true, []string{"t5", "ok1", "ok2"}},
+		})
+	})
+
+	t.Run("ShouldIgnoreErrorsInFinally", func(t *testing.T) {
+		runTests(t, reg, true, []testTaskCfg{
+			{"t6", []string{"err", "ok1"}, false, false, []string{"t6", "err", "ok1"}},
+		})
+	})
+
+	t.Run("ShouldErrorIfMisconfigured", func(t *testing.T) {
+		runTests(t, reg, true, []testTaskCfg{
+			{"t7", []string{"requiredArg"}, false, true, dummy},
+			{"t8", []string{"hasFinally"}, false, true, dummy},
+			{"t9", []string{"dependsOnNotAllowed"}, false, true, dummy},
+			{"t10", []string{"doesNotExist"}, false, true, dummy},
+		})
+	})
+
+	t.Run("ShouldReverseFinalizeDependencies", func(t *testing.T) {
+		declare(reg, "t11", false).DependsOn("t1", "t2").Finally("err")
+		declare(reg, "t12", true).DependsOn("t1", "t2").Finally("dep")
+		declare(reg, "t13", false).DependsOn("t11").Finally("ok1")
+		declare(reg, "t14", false).DependsOn("t12").Finally("ok1")
+
+		runTests(t, reg, false, []testTaskCfg{
+			{"t11", dummy, false, false, []string{"t1", "t2", "t11", "err", "ok1", "ok2"}},
+			{"t12", dummy, false, true, []string{"t1", "t2", "t12", "ok1", "ok2", "dep"}},
+			{"t13", dummy, false, false, []string{"t1", "t2", "t11", "t13", "ok1", "err", "ok2"}},
+			{"t14", dummy, false, true, []string{"t1", "t2", "t12", "ok1", "ok2", "dep"}},
+		})
+	})
+}

--- a/task/sort.go
+++ b/task/sort.go
@@ -108,7 +108,7 @@ func validateDeferredTasks(allTasksMap map[string]Task, deferredTaskStates map[s
 			if !ok {
 				return fmt.Errorf("unknown task '%s'", taskName)
 			}
-			if len(task.DeferredTasks()) > 0 || hasNonOptionalArg(task) {
+			if len(task.DeferredTasks()) > 0 {
 				return fmt.Errorf("'%s' cannot be deferred", taskName)
 			}
 			if err := validateDeferredTasks(allTasksMap, deferredTaskStates, task.Dependencies()); err != nil {
@@ -120,13 +120,4 @@ func validateDeferredTasks(allTasksMap map[string]Task, deferredTaskStates map[s
 		}
 	}
 	return nil
-}
-
-func hasNonOptionalArg(task Task) bool {
-	for _, arg := range task.DeclaredArgs() {
-		if arg.Validator != nil {
-			return true
-		}
-	}
-	return false
 }

--- a/task/sort.go
+++ b/task/sort.go
@@ -27,6 +27,7 @@ func buildGraph(allTasks []Task, requiredTaskNames []string) ([]*graphNode, erro
 
 	var g []*graphNode
 	seenTasks := make(map[string]struct{})
+	seenFinallyTasks := make(map[string]int)
 	for len(requiredTaskNames) > 0 {
 		taskName := requiredTaskNames[0]
 		requiredTaskNames = requiredTaskNames[1:]
@@ -38,7 +39,11 @@ func buildGraph(allTasks []Task, requiredTaskNames []string) ([]*graphNode, erro
 
 		if _, ok := seenTasks[task.Name()]; !ok {
 			seenTasks[task.Name()] = struct{}{}
-			g = append(g, &graphNode{task: task, edges: task.Dependencies()})
+			if err := validateFinallyClause(allTasksMap, seenFinallyTasks, task); err != nil {
+				return nil, err
+			}
+			g = append(g, &graphNode{task: task, edges: append([]string{}, task.Dependencies()...)})
+
 			requiredTaskNames = append(requiredTaskNames, task.Dependencies()...)
 		}
 	}
@@ -84,4 +89,42 @@ func toposort(g []*graphNode) ([]Task, error) {
 	}
 
 	return sorted, nil
+}
+
+func validateFinallyClause(allTasksMap map[string]Task, seenFinallyTasks map[string]int, task Task) error {
+	if len(task.Finally()) > 0 && task.Executor() == nil {
+		return fmt.Errorf("task '%s' without executor cannot use Finally", task.Name())
+	}
+	return validateFinallyTasks(allTasksMap, seenFinallyTasks, task.Finally()...)
+}
+
+func validateFinallyTasks(allTasksMap map[string]Task, seenFinallyTasks map[string]int, finallyTaskNames ...string) error {
+	for _, taskName := range finallyTaskNames {
+		if seenFinallyTasks[taskName] == 0 {
+			seenFinallyTasks[taskName] = -1
+			task, ok := allTasksMap[strings.ToLower(taskName)]
+			if !ok {
+				return fmt.Errorf("unknown task '%s'", taskName)
+			}
+			if len(task.Finally()) > 0 || hasNonOptionalArg(task) {
+				return fmt.Errorf("'%s' not allowed in Finally", taskName)
+			}
+			if err := validateFinallyTasks(allTasksMap, seenFinallyTasks, task.Dependencies()...); err != nil {
+				return err
+			}
+			seenFinallyTasks[taskName] = 1
+		} else if seenFinallyTasks[taskName] == -1 {
+			return fmt.Errorf("Finally cycle detected")
+		}
+	}
+	return nil
+}
+
+func hasNonOptionalArg(task Task) bool {
+	for _, arg := range task.DeclaredArgs() {
+		if arg.Validator != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/task/sort_test.go
+++ b/task/sort_test.go
@@ -98,6 +98,6 @@ func (t dummyTask) Hidden() bool {
 func (t dummyTask) Name() string {
 	return string(t)
 }
-func (t dummyTask) Finally() []string {
+func (t dummyTask) DeferredTasks() []string {
 	return nil
 }

--- a/task/sort_test.go
+++ b/task/sort_test.go
@@ -98,3 +98,6 @@ func (t dummyTask) Hidden() bool {
 func (t dummyTask) Name() string {
 	return string(t)
 }
+func (t dummyTask) Finally() []string {
+	return nil
+}

--- a/task/task.go
+++ b/task/task.go
@@ -11,6 +11,7 @@ type Task interface {
 	Executor() Executor
 	Hidden() bool
 	Name() string
+	Finally() []string
 }
 
 type sortedTasks []Task

--- a/task/task.go
+++ b/task/task.go
@@ -11,7 +11,7 @@ type Task interface {
 	Executor() Executor
 	Hidden() bool
 	Name() string
-	Finally() []string
+	DeferredTasks() []string
 }
 
 type sortedTasks []Task

--- a/task/tui.go
+++ b/task/tui.go
@@ -59,3 +59,12 @@ func (ui *TUI) Success(msg string) string {
 
 	return ansi.Color(msg, "green+b")
 }
+
+// Warning colors the msg as warning.
+func (ui *TUI) Warning(msg string) string {
+	if ui == nil {
+		return msg
+	}
+
+	return ansi.Color(msg, "yellow+b")
+}

--- a/task/usage.go
+++ b/task/usage.go
@@ -70,8 +70,8 @@ func usageTemp(ui *TUI, fs *flag.FlagSet, registry *Registry, longestLine int, o
 		if t.Description() != "" {
 			fmt.Fprintln(out, "       ", t.Description())
 		}
-		if len(t.Finally()) > 0 {
-			fmt.Fprintln(out, "       ", ui.Highlight("finally"), "->", t.Finally())
+		if len(t.DeferredTasks()) > 0 {
+			fmt.Fprintln(out, "       ", ui.Highlight("deferred"), "->", t.DeferredTasks())
 		}
 	}
 	fmt.Fprintln(out)

--- a/task/usage.go
+++ b/task/usage.go
@@ -70,6 +70,9 @@ func usageTemp(ui *TUI, fs *flag.FlagSet, registry *Registry, longestLine int, o
 		if t.Description() != "" {
 			fmt.Fprintln(out, "       ", t.Description())
 		}
+		if len(t.Finally()) > 0 {
+			fmt.Fprintln(out, "       ", ui.Highlight("finally"), "->", t.Finally())
+		}
 	}
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "OPTIONS:")


### PR DESCRIPTION
**Context:** `DependsOn()` allows tasks to build on the actions performed by other tasks. This is especially useful to avoid repeat logic when multiple tasks require the same or similar setup steps, e.g. integration/e2e test tasks that need to build the same binaries, generate artifacts or prepare the filesystem before executing individual tests.

**The Problem:** Tasks may also involve redundant/repetitive actions *after* executing, e.g. to revert setup steps, perform cleanup or do other forms of post processing, which currently can only be done by the task itself. Besides the added complexity for work often unrelated to the task's primary objective, careful handling of errors is required to ensure post-task actions are not inadvertently skipped if the task fails. It can also be desirable to defer post-task actions, e.g. tearing down a setup that is needed for multiple tasks, which is not possible in this model.

**The Solution:** This PR adds the builder method `Defer(names ...string)`, allowing tasks to declare one or more other tasks that will be run at the end of regular task execution, regardless of whether the current task itself succeeded or failed.

Example:
```
reg := NewRegistry()
reg.Declare("clean").Do(...)
reg.Declare("build").Do(...)
reg.Declare("e2e").DependsOn("clean", "build").Defer("clean").Do(...)
```
Running task `e2e` executes `clean` -> `build` -> `e2e` -> `clean`

---

Constraints
- This feature is primarily intended for executing actions that are simple in nature and do not make a lot of assumptions about their environment or are likely to fail
- Any task declaration may include `Defer()`, but it only allows referencing tasks that **do not** use `Defer()` themselves or depend on a task that does
- Runtime checks enforce these constraints before any task is executed
- Deferred tasks can receive arguments just like regular tasks
	- **Note**: If a task is part of regular *and* deferred execution it will receive the same set of arguments in both cases
- Errors in deferred tasks are logged as warnings but do not prevent others from running or impact the overall execution result

Execution Details
- Deferred tasks only run if the underlying task started execution, but regardless of whether it succeeded
- Any individual deferred task is only run once, even if specified by multiple tasks
- If execution involves multiple tasks `T1...Tn`, the respective deferred tasks are executed in reverse order `Tn...T1`
	- Ex: Tasks `T1.Defer("F1")` and `T2.DependsOn("T1").Defer("F2")`
		- Running `T2` executes `T1` -> `T2` -> `F2` -> `F1`