### PR TITLE
MHOUSE-9623: Add in option for JSON output

### DIFF
--- a/task/internal/json_logger.go
+++ b/task/internal/json_logger.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const (
+	startTimeNanosField = "startTimeNanos"
+	msgField            = "msg"
+)
+
+type JSONLogger struct {
+	w  io.Writer
+	id string
+}
+
+// NewJSONLogger creates a new JSONLogger which generates valid JSON ouputs and includes the same unique
+// id in each log line generated through this logger.
+func NewJSONLogger(w io.Writer) *JSONLogger {
+	return &JSONLogger{
+		w: w,
+		// Use nano timestamps as a decent unique identifier that does not
+		// require any external dependencies.
+		id: fmt.Sprintf("%d", time.Now().UnixNano()),
+	}
+}
+
+func (j *JSONLogger) Logln(msg string, fields map[string]string) {
+	_, _ = j.logln(msg, fields)
+}
+
+func (j *JSONLogger) logln(msg string, fields map[string]string) (int, error) {
+	fields[msgField] = msg
+	fields[startTimeNanosField] = j.id
+	logString, err := json.Marshal(fields)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Fprintln(j.w, string(logString))
+}
+
+// Write implements the [io.Writer] interface. The input is expected to be log lines separated by newlines.
+// If the log line is already valid JSON, the logger simply adds the id field. If the log line is not valid JSON,
+// then the log line is wrapped in a JSON.
+func (j *JSONLogger) Write(p []byte) (int, error) {
+	// p may contain any number of log lines, so split the input by newline.
+	for _, line := range strings.Split(strings.TrimRight(string(p), "\n"), "\n") {
+		_, err := j.writeLine([]byte(line))
+		if err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+func (j *JSONLogger) writeLine(line []byte) (int, error) {
+	log := map[string]interface{}{}
+
+	err := json.Unmarshal(line, &log)
+	if err != nil {
+		// If the log is not a valid JSON, log it as a field of a valid JSON.
+		return j.logln(string(line), map[string]string{})
+	}
+
+	// If the log is already in JSON format, just add in the id field.
+	log[startTimeNanosField] = j.id
+	logString, err := json.Marshal(log)
+	if err != nil {
+		return 0, err
+	}
+	return fmt.Fprintln(j.w, string(logString))
+}


### PR DESCRIPTION
### MHOUSE-9623

This PR aims to help generate a structured-logging output from goke task runs, for the main purpose of ADF Liveness Tests (aka "Smoke tests"), so that the logs generated by the liveness test runner can be processed by Splunk.

I've connected this version to `mongohouse`, and ran the smoke tests with the `-json` flag.

The output looks like
```
{
  "msg": "starting task",
  "startTime": "2024-02-06 00:51:30.257421 +0000 UTC",
  "startTimeNanos": "1707180690257417000",
  "task": "test:smoke"
}
{
  "msg": "Running Atlas Data Lake smoke tests in production",
  "startTimeNanos": "1707165249860987000"
}
{
  "msg": "Deployment environment is production",
  "startTimeNanos": "1707165249860987000"
}
{
  "Action": "output",
  "Output": "=== RUN   TestCountQueries\n",
  "Package": "command-line-arguments",
  "Test": "TestCountQueries",
  "Time": "2024-02-05T15:34:11.358638-05:00",
  "startTimeNanos": "1707165249860987000"
}
{
  "Action": "output",
  "Output": "--- PASS: TestCountQueries (0.00s)\n",
  "Package": "command-line-arguments",
  "Test": "TestCountQueries",
  "Time": "2024-02-05T15:34:17.329624-05:00",
  "startTimeNanos": "1707165249860987000"
}
{
  "Action": "pass",
  "Elapsed": 0.26,
  "Package": "command-line-arguments",
  "Test": "TestCountQueries",
  "Time": "2024-02-05T19:51:34.998003-05:00",
  "startTimeNanos": "1707180690257417000"
}
```